### PR TITLE
Fix compile and link options, should still work with older SDK.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ EXTRA_INCDIR    = include
 LIBS		= c gcc hal pp phy net80211 lwip_open_napt wpa main
 
 # compiler flags using during compilation of source files
-CFLAGS		= -Os -g -O2 -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH -DLWIP_OPEN_SRC -DUSE_OPTIMIZE_PRINTF
+CFLAGS		= -Os -ffunction-sections -fdata-sections -g -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH -DLWIP_OPEN_SRC -DUSE_OPTIMIZE_PRINTF
 
 # linker flags used to generate the main object file
-LDFLAGS		= -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static -L.
+LDFLAGS		= -ffunction-sections -fdata-sections -Wl,-gc-sections -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static -L.
 
 # linker script used for the above linkier step
 #LD_SCRIPT	= eagle.app.v6.ld


### PR DESCRIPTION
Fix compile and link options, should still work with older SDK. as it says!
Clone https://github.com/xxxajk/esp-open-sdk to get latest SDK.
