### PR TITLE
Minor updates to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you like, you can mark the "lock" checkbox and click "Lock". Now the config c
 
 If you want to enter non-ASCII or special characters in the web interface you have to use HTTP-style hex encoding like "My%20AccessPoint". This will result in a string "My AccessPoint". With this hex encoding you can enter any byte value you like, except for 0 (for C-internal reasons).
 
-If you did a mistake and you lost any contact with the ESP you can still use the serial console to recover it ("reset facory", see below).
+If you made a mistake and have lost all contact with the ESP you can still use the serial console to recover it ("reset factory", see below).
 
 # Command Line Interface
 Advanced configuration has to be done via the command line on the console interface. This console is available either via the serial port at 115200 baud or via tcp port 7777 (e.g. "telnet 192.168.4.1 7777" from a connected STA).

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ python -m SimpleHTTPServer 8080
 ```
 Set the parameter _hostname_ to the hostname or IP of your computer, set _portno_ to 8080, and "save". Then type on the CLI:
 ```
-ota upgrade
+ota update
 ```
 If configured correctly, the update will start and the ESP will reboot with the new binary.
 

--- a/README.md
+++ b/README.md
@@ -159,12 +159,12 @@ In default config GPIO2 is configured to drive a status LED (connected to GND) w
 - flashing (1 per second): working, connected to the AP
 - unperiodically flashing: working, traffic in the internal network
 
-With "set status_led GPIOno" the GPIO pin can be changed (any value > 16, e.g. "set status_led 255" will disable the status LED completely). When configured to GPIO1, it works with the buildin blue LED on the ESP-01 boards. However, as GPIO1 ist also the UART-TX-pin this means, that the serial console is not working. Configuration is then limited to network access.
+With "set status_led GPIOno" the GPIO pin can be changed (any value > 16, e.g. "set status_led 255" will disable the status LED completely). When configured to GPIO1, it works with the built-in blue LED on the ESP-01 boards. However, as GPIO1 is also the UART-TX-pin this means, that the serial console is not working. Configuration is then limited to network access.
 
 # HW Factory Reset
 If you pull low a selected GPIO for more than 3 seconds, the repeater will do a factory reset and restart with default config. With "set hw_reset GPIOno" the GPIO pin can be changed (any value > 16, e.g. "set hw_reset 255" will disable the hw factory reset feature).
 
-For many moduls, incl. ESP-01s and NodeMCUs, it is probably a good idea to use GPIO 0 for that, as it is used anyway. However, it is not the default pin, as it might interfere with pulling it down during flashing. Thus, if you want to use an existing push button on GPIO 0 for HW factory reset, configure it with "set hw_reset 0" and "save" after flashing. A factory reset triggered by the HW pin will NOT reset the configured hw_reset GPIO number ("reset factory" from console will do).
+For many modules, incl. ESP-01s and NodeMCUs, it is probably a good idea to use GPIO 0 for that, as it is used anyway. However, it is not the default pin, as it might interfere with pulling it down during flashing. Thus, if you want to use an existing push button on GPIO 0 for HW factory reset, configure it with "set hw_reset 0" and "save" after flashing. A factory reset triggered by the HW pin will NOT reset the configured hw_reset GPIO number ("reset factory" from console will do).
 
 # Port Mapping
 In order to allow clients from the external network to connect to server port on the internal network, ports have to be mapped. An external port is mapped to an internal port of a specific internal IP address. Use the "portmap add" command for that. Port mappings can be listed with the "show" command and are saved with the current config. 
@@ -288,7 +288,7 @@ This allows you to configure a multi-star topology of ESPs, where each ESP and i
 By setting upstream_kbps and downstream_kbps to a value != 0 (0 is the default), you can limit the maximum bitrate of the ESP's AP. This value is a limit that applies to the traffic of all connected clients. Packets that would exeed the defined bitrate are dropped. The traffic shaper uses the "Token Bucket" algorithm with a bucket size of currently four times the bitrate per seconds, allowing for bursts, when there was no traffic before.
 
 # MQTT Support
-Since version 1.3 the router has a build-in MQTT client (thanks to Tuan PM for his library https://github.com/tuanpmt/esp_mqtt). This can help to integrate the router/repeater into the IoT. A home automation system can e.g. make decisions based on infos about the currently associated stations, it can switch on and of the repeaters (e.g. based on a time schedule), or it can simply be used to monitor the load. The router can be connected either to a local MQTT broker or to a publicly available broker in the cloud. However, currently it does not support TLS encryption.
+Since version 1.3 the router has a built-in MQTT client (thanks to Tuan PM for his library https://github.com/tuanpmt/esp_mqtt). This can help to integrate the router/repeater into the IoT. A home automation system can e.g. make decisions based on infos about the currently associated stations, it can switch on and of the repeaters (e.g. based on a time schedule), or it can simply be used to monitor the load. The router can be connected either to a local MQTT broker or to a publicly available broker in the cloud. However, currently it does not support TLS encryption.
 
 By default the MQTT client is disabled. It can be enabled by setting the config parameter "mqtt_host" to a hostname different from "none". To configure MQTT you can set the following parameters:
 - set mqtt_host _IP_or_hostname_: IP or hostname of the MQTT broker ("none" disables the MQTT client)

--- a/README.md
+++ b/README.md
@@ -268,11 +268,11 @@ Here is a simple example of what can be done with static routes. Given the follo
 ```
 Each ESP has a second network behind its AP with different network addresses: 10.0.1.0/24 and 10.0.2.0/24. ESP1 can ping to ESP2 to the 192.168.1.20 but not to the 10.0.2.1, as it doesn't know that it can reach it via the 192.168.1.20. This changes if you add two static routes. On ESP1:
 ```
-route add 10.0.2.0/24 92.168.1.20
+route add 10.0.2.0/24 192.168.1.20
 ```
 and on ESP2:
 ```
-route add 10.0.1.0/24 92.168.1.10
+route add 10.0.1.0/24 192.168.1.10
 ```
 Now a "ping 10.0.2.1" on ESP1 will be successful. It is send to 192.168.1.20 and then answered by ESP2.
 


### PR DESCRIPTION
Hi Martin,

   I've been working through your latest release on an ESP-01S today and came across a couple of minor issues in the README.md file.  Nothing very spectacular, just typos.  The main ones were a missing leading "1" character in the IP addresses in the route examples (lines 271 & 275) and the wrong command for the ota update instruction on line 408.  There was a typo in the word "factory" on line 48, where I also made a couple of very minor changes to the wording to give the sentence a more natural flow.

  Anyway, as before, I'm very impressed not just with the package, but also with the amount of detail you've put into the README.  Today I took the simplest route and just loaded your pre-built binaries into the ESP01S and then followed your instructions to get the repeater/router up and running, followed by an OTA update.  It was a fun use of time on a dreary winters day (sleet outside, a nice warm woodstove inside).

   The next step is to hook up a Wiznet W5500 or W820io and an ESP12 to see whether the ethernet connection will work (I might have to wait for another snowy or rainy day for that, though).

   Many thanks for all the effort you've put into this package,

                                                                      -John-
