### PR TITLE
Added command "gpio <pin> set high|low for <seconds>"

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Most of the set-commands are effective only after save and reset.
 - set vmin_sleep _secs_: sets the time interval in seconds the ESP sleeps on low voltage
 - gpio [0-16] mode [_in_|_in_pullup_|_out_]: configures a GPIO port of the ESP (saved to flash)
 - gpio [0-16] set [_high_|_low_]: writes to an output port
+- gpio [0-16] set [_high_|_low_] for _seconds_: writes to an output port and reverts after a certain duration
 - gpio [0-16] get: reads from an input port
 
 # Status LED


### PR DESCRIPTION
Hello Martin,

First I realize that I never took the opportunity to thank you for the great job you did with this Wifi repeater. Really well done!

I use it for IoT with Wemos, connected together (automesh), driving various devices such as pool pumps, gates, or whatever. However, these meshed Wemos would be even better if it was possible to define some basic logic for the GPIOs.

The first improvement I propose is to add a timer to the `gpio <pin> set high|low` command. This is particularly useful when you want to drive a device that reacts to pushbutton pulses, such as a gate for instance. It avoids sending a `set low` right after a `set high`.

What do you think?