### PR TITLE
Added gpio trigger command, to link input GPIOs to output GPIOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Most of the set-commands are effective only after save and reset.
 - gpio [0-16] set [_high_|_low_]: writes to an output port
 - gpio [0-16] set [_high_|_low_] for _seconds_: writes to an output port and reverts after a certain duration
 - gpio [0-16] get: reads from an input port
+- gpio [0-16] trigger [0-16] [_monostable_NO_|_monostable_NC_|_bistable_]: links an input port to an output port, either as a monostable normally open (pushbutton triggering when state change to low), a monostable normally closed (pushbutton triggering when state change to high) or a bistable (switch).
+- gpio [0-16] trigger none: clears the link.
 
 # Status LED
 In default config GPIO2 is configured to drive a status LED (connected to GND) with the following indications:

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Most of the set-commands are effective only after save and reset.
 - gpio [0-16] get: reads from an input port
 - gpio [0-16] trigger [0-16] [_monostable_NO_|_monostable_NC_|_bistable_]: links an input port to an output port, either as a monostable normally open (pushbutton triggering when state change to low), a monostable normally closed (pushbutton triggering when state change to high) or a bistable (switch).
 - gpio [0-16] trigger none: clears the link.
+- show gpio: displays the gpio configuration.
 
 # Status LED
 In default config GPIO2 is configured to drive a status LED (connected to GND) with the following indications:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Most of the set-commands are effective only after save and reset.
 - gpio [0-16] set [_high_|_low_]: writes to an output port
 - gpio [0-16] set [_high_|_low_] for _seconds_: writes to an output port and reverts after a certain duration
 - gpio [0-16] get: reads from an input port
-- gpio [0-16] trigger [0-16] [_monostable_NO_|_monostable_NC_|_bistable_]: links an input port to an output port, either as a monostable normally open (pushbutton triggering when state change to low), a monostable normally closed (pushbutton triggering when state change to high) or a bistable (switch).
+- gpio [0-16] trigger [0-16] [_monostable_NO_|_monostable_NC_|_bistable_NO_|_bistable_NC_]: links an input port to an output port, either as a monostable normally open (pushbutton triggering when state change to low), a monostable normally closed (pushbutton triggering when state change to high), a bistable normally open (switch replicating the input), or a bistable normally closed (switch which state is the opposite of the input).
 - gpio [0-16] trigger none: clears the link.
 - show gpio: displays the gpio configuration.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Most of the set-commands are effective only after save and reset.
 - gpio [0-16] set [_high_|_low_]: writes to an output port
 - gpio [0-16] set [_high_|_low_] for _seconds_: writes to an output port and reverts after a certain duration
 - gpio [0-16] get: reads from an input port
-- gpio [0-16] trigger [0-16] [_monostable_NO_|_monostable_NC_|_bistable_NO_|_bistable_NC_]: links an input port to an output port, either as a monostable normally open (pushbutton triggering when state change to low), a monostable normally closed (pushbutton triggering when state change to high), a bistable normally open (switch replicating the input), or a bistable normally closed (switch which state is the opposite of the input).
+- gpio [0-16] trigger [0-16] [_monostable_NO_|_monostable_NC_|_bistable_NO_|_bistable_NC_]: links an input port to an output port, either as a monostable normally open (pushbutton triggering when state changes to low), a monostable normally closed (pushbutton triggering when state changes to high), a bistable normally open (switch replicating the input), or a bistable normally closed (switch which state is the opposite of the input).
 - gpio [0-16] trigger none: clears the link.
 - show gpio: displays the gpio configuration.
 

--- a/user/config_flash.c
+++ b/user/config_flash.c
@@ -163,7 +163,11 @@ uint32_t reg0, reg1, reg3;
 #if GPIO_CMDS
     int i;
     for (i=0; i<17; i++)
+    {
         config->gpiomode[1] = UNDEFINED;
+        config->gpio_trigger_pin[i] = -1;
+        config->gpio_trigger_type[i] = NONE;
+    }
 #endif
 }
 

--- a/user/config_flash.h
+++ b/user/config_flash.h
@@ -26,6 +26,9 @@ typedef enum {
 typedef enum {
         UNDEFINED = 0, OUT, IN, IN_PULLUP
 } gpio_mode;
+typedef enum {
+        NONE = 0, MONOSTABLE_NO, MONOSTABLE_NC, BISTABLE
+} gpio_trigger_type;
 #endif
 
 typedef struct {
@@ -147,6 +150,8 @@ typedef struct {
 #endif
 #if GPIO_CMDS
         gpio_mode gpiomode[17];
+        gpio_trigger_type gpio_trigger_type[17];
+        uint8_t gpio_trigger_pin[17];
 #endif
 } sysconfig_t, *sysconfig_p;
 

--- a/user/config_flash.h
+++ b/user/config_flash.h
@@ -27,7 +27,7 @@ typedef enum {
         UNDEFINED = 0, OUT, IN, IN_PULLUP
 } gpio_mode;
 typedef enum {
-        NONE = 0, MONOSTABLE_NO, MONOSTABLE_NC, BISTABLE
+        NONE = 0, MONOSTABLE_NO, MONOSTABLE_NC, BISTABLE_NO, BISTABLE_NC
 } gpio_trigger_type;
 #endif
 

--- a/user/user_config.h
+++ b/user/user_config.h
@@ -18,7 +18,7 @@
 //
 // Size of the console buffers
 //
-#define		MAX_CON_SEND_SIZE 1300
+#define		MAX_CON_SEND_SIZE 1500
 #define		MAX_CON_CMD_SIZE 80
 
 //

--- a/user/user_main.c
+++ b/user/user_main.c
@@ -1005,6 +1005,11 @@ void ICACHE_FLASH_ATTR console_handle_command(struct espconn *pespconn)
 #else
 		""
 #endif
+#if GPIO_CMDS
+        "|gpio"
+#else
+        ""
+#endif
 #if OTAUPDATE
 		"|ota"
 #else
@@ -1437,6 +1442,33 @@ void ICACHE_FLASH_ATTR console_handle_command(struct espconn *pespconn)
 		config.mqtt_id, config.mqtt_prefix, config.mqtt_qos, config.mqtt_command_topic, config.mqtt_gpio_out_topic, config.mqtt_interval, config.mqtt_topic_mask);
 	   to_console(response);
 	   goto command_handled_2;
+      }
+#endif
+#if GPIO_CMDS
+      if (nTokens == 2 && strcmp(tokens[1], "gpio") == 0) {
+        uint pin;
+        for(pin=0; pin<17; pin++) {
+            char *mode = NULL;
+            if (config.gpiomode[pin]==OUT) mode = "out";
+            if (config.gpiomode[pin]==IN) mode = "in";
+            if (config.gpiomode[pin]==IN_PULLUP) mode = "in_pullup";
+            if (mode) {
+                char *type = NULL;
+                if ((config.gpiomode[pin]==IN || config.gpiomode[pin]==IN_PULLUP) && config.gpio_trigger_pin[pin]!=-1) {
+                    if (config.gpio_trigger_type[pin]==MONOSTABLE_NC) type = "monostable normally closed";
+                    if (config.gpio_trigger_type[pin]==MONOSTABLE_NO) type = "monostable normally open";
+                    if (config.gpio_trigger_type[pin]==BISTABLE) type = "bistable";
+                }
+                os_sprintf(response, "GPIO %d: %s", pin, mode);
+                to_console(response);
+                if (type) {
+                    os_sprintf(response, ", triggers GPIO %d as a %s", config.gpio_trigger_pin[pin], type);
+                    to_console(response);
+                }
+                to_console("\r\n");
+            }
+        }
+        goto command_handled_2;
       }
 #endif
 #if OTAUPDATE

--- a/user/user_main.c
+++ b/user/user_main.c
@@ -877,8 +877,11 @@ void handlePinValueChange(uint16_t pin) {
                         do_outputSet(trigger_pin, !prev_values[trigger_pin], 0);
                     }
                     break;
-                case BISTABLE:
+                case BISTABLE_NO:
                     do_outputSet(trigger_pin, val, 0);
+                    break;
+                case BISTABLE_NC:
+                    do_outputSet(trigger_pin, !val, 0);
                     break;
             }
         }
@@ -1457,7 +1460,8 @@ void ICACHE_FLASH_ATTR console_handle_command(struct espconn *pespconn)
                 if ((config.gpiomode[pin]==IN || config.gpiomode[pin]==IN_PULLUP) && config.gpio_trigger_pin[pin]!=-1) {
                     if (config.gpio_trigger_type[pin]==MONOSTABLE_NC) type = "monostable normally closed";
                     if (config.gpio_trigger_type[pin]==MONOSTABLE_NO) type = "monostable normally open";
-                    if (config.gpio_trigger_type[pin]==BISTABLE) type = "bistable";
+                    if (config.gpio_trigger_type[pin]==BISTABLE_NC) type = "bistable normally closed";
+                    if (config.gpio_trigger_type[pin]==BISTABLE_NO) type = "bistable normally open";
                 }
                 os_sprintf(response, "GPIO %d: %s", pin, mode);
                 to_console(response);
@@ -2780,9 +2784,9 @@ void ICACHE_FLASH_ATTR console_handle_command(struct espconn *pespconn)
                 const char *type = tokens[4];
                 uint16_t linked_pin = atoi(tokens[3]); // 0-16
 
-                if (strcmp(type, "monostable_NO")!=0 && strcmp(type, "monostable_NC")!=0 && strcmp(type, "bistable")!=0) 
+                if (strcmp(type, "monostable_NO")!=0 && strcmp(type, "monostable_NC")!=0 && strcmp(type, "bistable_NO")!=0 && strcmp(type, "bistable_NC")!=0) 
                 {
-                        os_sprintf_flash(response, "Invalid type (monostable_NO, monostable_NC or bistable)\r\n");
+                        os_sprintf_flash(response, "Invalid type (monostable_NO, monostable_NC, bistable_NO or bistable_NC)\r\n");
                         goto command_handled;
                 }
 
@@ -2794,7 +2798,8 @@ void ICACHE_FLASH_ATTR console_handle_command(struct espconn *pespconn)
 
                 if (strcmp(type, "monostable_NO")==0) config.gpio_trigger_type[pin] = MONOSTABLE_NO;
                 if (strcmp(type, "monostable_NC")==0) config.gpio_trigger_type[pin] = MONOSTABLE_NC;
-                if (strcmp(type, "bistable")==0) config.gpio_trigger_type[pin] = BISTABLE;
+                if (strcmp(type, "bistable_NO")==0) config.gpio_trigger_type[pin] = BISTABLE_NO;
+                if (strcmp(type, "bistable_NC")==0) config.gpio_trigger_type[pin] = BISTABLE_NC;
                 config.gpio_trigger_pin[pin] = linked_pin;
                 goto command_handled;
             }


### PR DESCRIPTION
Hi Martin,

This PR allows to link an output GPIO to an input GPIO: a state change of the input GPIO will trigger a state change of the output GPIO. There are 4 ways to do the link: monostable normally open or normally closed, and bistable nomally open or normally closed.

The "bistable normally closed" mode replicates the state of the input GPIO to the output GPIO. As the state change is published on MQTT, it is very convenient to track the state change. I use it in my home automation in a Wemos with a relay shield to track when somebody presses the bell. The bell push button is connected to the input GPIO, and the output GPIO to the relay. The relay closes the wires when the button is pushed.

I have also added the 'show gpio' command that displays the current gpio configuration.

Hoping it will be useful to other!