### PR TITLE
Fixes to GPIO features

### DIFF
--- a/user/user_main.c
+++ b/user/user_main.c
@@ -3848,6 +3848,8 @@ struct espconn *pCon;
         if (config.gpiomode[i] == OUT) {
             easygpio_pinMode(i, EASYGPIO_NOPULL, EASYGPIO_OUTPUT);
         }
+    }
+    for (i=0; i<17; i++) {
         if (config.gpiomode[i] == IN) {
 #if MQTT_CLIENT
             easygpio_attachInterrupt(i, EASYGPIO_NOPULL, gpio_change_handler, (void *)(intptr_t)i);
@@ -3855,6 +3857,7 @@ struct espconn *pCon;
 #else
             easygpio_pinMode(i, EASYGPIO_NOPULL, EASYGPIO_INPUT);
 #endif
+            handlePinValueChange(i);        
         }
         if (config.gpiomode[i] == IN_PULLUP) {
 #if MQTT_CLIENT
@@ -3863,6 +3866,7 @@ struct espconn *pCon;
 #else
             easygpio_pinMode(i, EASYGPIO_PULLUP, EASYGPIO_INPUT);
 #endif
+            handlePinValueChange(i);        
         }
     }
 #endif


### PR DESCRIPTION
Hello,

Here are 2 fixes to the GPIO features:
- GPIO trigger were not executed at init of the ESP
- a bug was causing a crash in case 2 input GPIOs had their state changed at the exact same time

Regards,
Bruno