### PR TITLE
Allow specifying an ap_ssid (and possibly password) in Automesh mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Now each esp_wifi_repeater can learn which other esp_wifi_repeater is the closes
 
 For convenience, the esp_wifi_repeater after "automesh" configuration first tries to check, whether it can connect to an uplink AP. If this fails, even when an AP with the correct SSID has been found, it assumes, the user did a mistake with the password and resets to factory defaults. After it had connected successfully once, it will assume config is correct and keep on trying after connection loss or reset as long as it takes (to avoid a DOS attack with a misconfigured AP). 
 
+An option is to set a specific ap_ssid (and possibly ap_password). In that case, the "automesh" mode will create a dedicated WiFi network where each ESP will be connected either to the orginal network or to the dedicated network, but will be reachable only through the ap_ssid. This can be useful if you want a dedicated network for your ESPs (e.g. for IoT).
+
 ## Tuning Automesh
 If there are more than one ESP in range, there might be a trade-off between a shorter "bad" path and a longer "good" path (good and bad in terms of link quality). The parameter _am_threshold_ determines what a bad connection is: if the RSSI in a scan is less than this threshold, a connection is bad and path with one more hop is prefered. I.e. given _am_threshold_ is 85 and there are two automesh nodes detected in the scan: A with level 1 and RSSI -88 dB and B with level 2 and RSSI -60 dB, then a link to A is considered as too bad (-88 dB < -_am_threshold_) and B is preferred. The new node will become a level 3 node with uplink via B. _am_threshold_ is given as a positive value but means a negative dB. A smaller value is better. 
 

--- a/user/config_flash.c
+++ b/user/config_flash.c
@@ -81,6 +81,7 @@ uint32_t reg0, reg1, reg3;
     config->automesh_threshold		= 85;
     config->am_scan_time		= 0;
     config->am_sleep_time		= 0;
+    config->automesh_use_ap_ssid= 0;
 
     config->nat_enable			= 1;
     config->tcp_timeout			= 0;  // use default

--- a/user/config_flash.h
+++ b/user/config_flash.h
@@ -70,6 +70,7 @@ typedef struct {
         int8_t automesh_threshold; // RSSI limit
         uint32_t am_scan_time; // Seconds for scanning
         uint32_t am_sleep_time; // Seconds for sleeping
+        uint8_t automesh_use_ap_ssid; // Indicates if ssid or ap_ssid has to be used
 
         uint8_t nat_enable; // Enable NAT on the AP netif;
 	uint32_t tcp_timeout; // NAT timeout of TCP connections

--- a/user/user_main.c
+++ b/user/user_main.c
@@ -3680,7 +3680,7 @@ void ICACHE_FLASH_ATTR automesh_scan_done(void *arg, STATUS status)
 
     for (bss_link = (struct bss_info *)arg; bss_link != NULL; bss_link = bss_link->next.stqe_next)
     {
-      if (os_strcmp(bss_link->ssid, config.ssid) == 0) {
+      if (os_strcmp(bss_link->ssid, config.ssid) == 0 || os_strcmp(bss_link->ssid, config.ap_ssid) == 0) {
 	uint8_t this_mesh_level;
 
         os_printf("Found: %d,\"%s\",%d,\""MACSTR"\",%d",
@@ -3888,8 +3888,13 @@ struct espconn *pCon;
 
     // In Automesh STA and AP passwords and credentials are the same
     if (config.automesh_mode != AUTOMESH_OFF) {
+        if (os_strcmp(config.ap_ssid, "none") == 0) {
 	os_memcpy(config.ap_ssid, config.ssid, sizeof(config.ssid));
+        } else {
+            if (os_strcmp(config.ap_ssid, "none") == 0) {
 	os_memcpy(config.ap_password, config.password, sizeof(config.password));
+            }
+        }
 
 	if (config.automesh_mode == AUTOMESH_LEARNING) {
 	  config.ap_on = 0;

--- a/user/user_main.c
+++ b/user/user_main.c
@@ -3891,7 +3891,7 @@ struct espconn *pCon;
         if (os_strcmp(config.ap_ssid, "none") == 0) {
 	os_memcpy(config.ap_ssid, config.ssid, sizeof(config.ssid));
         } else {
-            if (os_strcmp(config.ap_ssid, "none") == 0) {
+            if (os_strcmp(config.ap_password, "none") == 0) {
 	os_memcpy(config.ap_password, config.password, sizeof(config.password));
             }
         }

--- a/user/user_main.c
+++ b/user/user_main.c
@@ -3613,8 +3613,8 @@ void ICACHE_FLASH_ATTR user_set_station_config(void)
     //char hostname[40];
 
     /* Setup AP credentials */
-    os_sprintf(stationConf.ssid, "%s", config.ssid);
-    os_sprintf(stationConf.password, "%s", config.password);
+    os_sprintf(stationConf.ssid, "%s", config.automesh_use_ap_ssid?config.ap_ssid:config.ssid);
+    os_sprintf(stationConf.password, "%s", config.automesh_use_ap_ssid?config.ap_password:config.password);
     if (*(int*)config.bssid != 0) {
 	stationConf.bssid_set = 1;
 	os_memcpy(stationConf.bssid, config.bssid, 6);
@@ -3675,6 +3675,7 @@ void ICACHE_FLASH_ATTR automesh_scan_done(void *arg, STATUS status)
   {
     mesh_level = 0xff;
     int rssi = -1000;
+    bool automesh_use_ap_ssid = false;
 
     struct bss_info *bss_link;
 
@@ -3704,6 +3705,7 @@ void ICACHE_FLASH_ATTR automesh_scan_done(void *arg, STATUS status)
 	  rssi = bss_link->rssi;
 	  mesh_level = this_mesh_level;
 	  os_memcpy(config.bssid, bss_link->bssid, 6);
+      automesh_use_ap_ssid = os_strcmp(bss_link->ssid, config.ap_ssid) == 0;
 	}
       }
     }
@@ -3716,6 +3718,7 @@ void ICACHE_FLASH_ATTR automesh_scan_done(void *arg, STATUS status)
       config.AP_MAC_address[2] = mesh_level+1;
       os_get_random(&config.AP_MAC_address[3], 3);
 
+      config.automesh_use_ap_ssid = automesh_use_ap_ssid;
       wifi_set_macaddr(SOFTAP_IF, config.AP_MAC_address);
       user_set_softap_wifi_config();
 
@@ -3738,7 +3741,13 @@ void ICACHE_FLASH_ATTR automesh_scan_done(void *arg, STATUS status)
      os_printf("Scan fail !!!\r\n");
   }
 
-  os_printf("No AP with ssid %s found\r\n", config.ssid);
+    char *nor = "";
+    char *apssid = "";
+    if (os_strcmp(config.ap_ssid, "none") != 0) {
+        nor = " nor ";
+        apssid = config.ap_ssid;
+    }
+  os_printf("No AP with ssid %s%s%s found\r\n", config.ssid, nor, apssid);
 
 #if ALLOW_SLEEP
   if (config.am_scan_time && config.am_sleep_time) {


### PR DESCRIPTION
Hello,

This pull request is a possible answer to issue #305.

Specifying an ap_ssid (and possibly ap_password) in automesh mode, will create a second WiFi network. Each ESP will connect either to the orgin ssid or to the new network.

This can be useful if you want to have a dedicated network for your ESPs (e.g. for IoT).

Note that this feature is backward compatible with the existing automesh functionality.

As an example, here is the topology of my IoT network using `Wifi_Home_ESP`, while my home network is `Wifi_Home`:

```
SSID: Wifi_Home
a0:40:a0:99:cc:a7
||
|+--ESP_04a87b: Filtration piscine
|   AP SSID: Wifi_Home_ESP - 38:2b:78:04:a8:7b - 192.168.0.50
|   Version V2.2.9 (build: Fri May 10 17:48:48 2019)
|   Uptime: 1d 06:34:52, 0 KiB in (0 packets), 0 KiB out (0 packets)
|   Signal strength: 30% (-85 dBm), Free mem: 11032, Power supply: 2.967V, Clock: 80 MHz
|   No station connected
|
+--ESP_9c4c90: Grand Portail
   AP SSID: Wifi_Home_ESP - 5c:cf:7f:9c:4c:90 - 192.168.0.51
   Version V2.2.9 (build: Fri May 10 17:48:48 2019)
   Uptime: 1d 05:03:26, 52146 KiB in (512041 packets), 903406 KiB out (748075 packets)
   Signal strength: 44% (-78 dBm), Free mem: 8904, Power supply: 2.907V, Clock: 80 MHz
   2 stations connected
   |
   +--ESP_04a92c: Wemos D1 Mini du garage
      AP SSID: Wifi_Home_ESP - 38:2b:78:04:a9:2c - 10.24.1.3
      Version V2.2.9 (build: Fri May 10 17:48:48 2019)
      Uptime: 10:47:59, 0 KiB in (0 packets), 0 KiB out (0 packets)
      Signal strength: 34% (-83 dBm), Free mem: 11040, Power supply: 2.986V, Clock: 80 MHz
      No station connected

```

@martin-ger I just discovered a bug in my code that I need to fix. I will let you know when fixed.
@martin-ger code is now fully functional. If you find this PR useful, you can merge it, thanks!