### PR TITLE
Update web.h to not show the STA SSID password

### DIFF
--- a/user/web.h
+++ b/user/web.h
@@ -22,7 +22,7 @@ setTimeout(\"location.href = '/'\",10000);\
 </tr>\
 <tr>\
 <td>Password:</td>\
-<td><input type='text' name='password' value='%s'/></td>\
+<td><input type='password' name='password' value='%s'/></td>\
 </tr>\
 <td>Automesh:</td>\
 <td><input type='checkbox' name='am' value='mesh' %s></td>\


### PR DESCRIPTION
The STA SSID password was a regular text field. It is now a password field.
This doesn't add much security, but at least on android it doesn't use the autocomplete feature of my keyboard...

The other password fields have been left as is.

This would address https://github.com/martin-ger/esp_wifi_repeater/issues/351
