### PR TITLE
Fix various compile errors ...

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{c,cpp}]
+indent_style = space
+indent_size = 4
+max_line_length = 155

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode/

--- a/user/config_flash.c
+++ b/user/config_flash.c
@@ -313,7 +313,7 @@ void user_rf_pre_init() {
 /*
 // user_pre_init is required from SDK v3.0.0 onwards
 // It is used to register the parition map with the SDK, primarily to allow
-// the app to use the SDK's OTA capability.  We don't make use of that in 
+// the app to use the SDK's OTA capability.  We don't make use of that in
 // otb-iot and therefore the only info we provide is the mandatory stuff:
 // - RF calibration data
 // - Physical data
@@ -322,7 +322,7 @@ void user_rf_pre_init() {
 void ICACHE_FLASH_ATTR user_pre_init(void)
 {
   bool rc = false;
-  static const partition_item_t part_table[] = 
+  static const partition_item_t part_table[] =
   {
     {SYSTEM_PARTITION_RF_CAL,
      0x3fb000,
@@ -362,7 +362,7 @@ void ICACHE_FLASH_ATTR user_pre_init(void)
          break;
    }
 
-    static const partition_item_t part_table[] = 
+    static const partition_item_t part_table[] =
     {
         {SYSTEM_PARTITION_RF_CAL,
         rf_cal_sec * 0x1000,
@@ -376,7 +376,7 @@ void ICACHE_FLASH_ATTR user_pre_init(void)
     };
 
   // This isn't an ideal approach but there's not much point moving on unless
-  // or until this has succeeded cos otherwise the SDK will just barf and 
+  // or until this has succeeded cos otherwise the SDK will just barf and
   // refuse to call user_init()
   while (!rc)
   {
@@ -388,3 +388,36 @@ void ICACHE_FLASH_ATTR user_pre_init(void)
   return;
 }
 */
+
+uint32 ICACHE_FLASH_ATTR user_rf_cal_sector_set(void)
+{
+    enum flash_size_map size_map = system_get_flash_size_map();
+    uint32 rf_cal_sec = 0;
+
+    switch (size_map) {
+        case FLASH_SIZE_4M_MAP_256_256:
+            rf_cal_sec = 128 - 5;
+            break;
+        case FLASH_SIZE_8M_MAP_512_512:
+            rf_cal_sec = 256 - 5;
+            break;
+        case FLASH_SIZE_16M_MAP_512_512:
+        case FLASH_SIZE_16M_MAP_1024_1024:
+            rf_cal_sec = 512 - 5;
+            break;
+        case FLASH_SIZE_32M_MAP_512_512:
+        case FLASH_SIZE_32M_MAP_1024_1024:
+            rf_cal_sec = 1024 - 5;
+            break;
+        case FLASH_SIZE_64M_MAP_1024_1024:
+            rf_cal_sec = 2048 - 5;
+            break;
+        case FLASH_SIZE_128M_MAP_1024_1024:
+            rf_cal_sec = 4096 - 5;
+            break;
+        default:
+            rf_cal_sec = 0;
+            break;
+    }
+    return rf_cal_sec;
+}

--- a/user/user_main.c
+++ b/user/user_main.c
@@ -1,3 +1,4 @@
+#include "stdint.h"
 #include "c_types.h"
 #include "mem.h"
 #include "ets_sys.h"
@@ -306,7 +307,7 @@ void ICACHE_FLASH_ATTR user_do_ping(const char *name, ip_addr_t *ipaddr, void *a
         os_sprintf(response, "DNS lookup failed for: %s\r\n", name);
         to_console(response);
         system_os_post(0, SIG_CONSOLE_TX, (ETSParam)currentconn);
-        return;    
+        return;
     }
 
     ping_opt.count = 4;       //  try to ping how many times
@@ -3101,9 +3102,9 @@ void ICACHE_FLASH_ATTR console_handle_command(struct espconn *pespconn)
          *      Get GPIO pin 2 value:
          *          gpio 2 get
          *      Link GPIO input pin 5 to GPIO output pin 2 as a monostable normally open:
-         *          gpio 5 trigger 2 monostable_NO 
+         *          gpio 5 trigger 2 monostable_NO
          *      Clear previous link:
-         *          gpio 5 trigger none 
+         *          gpio 5 trigger none
          */
         if (nTokens < 3)
         {


### PR DESCRIPTION
```
user/acl.c:6:21: fatal error: lwip/ip.h: No such file or directory
 #include "lwip/ip.h"
                     ^
compilation terminated.
make: *** [build/user/acl.o] Error 1
```
changed `EXTRA_INCDIR`

```
(hmueller@mbp2)~/src/esp8266/esp_wifi_repeater.hmueller01> make SDK_BASE=../esp-open-sdk/ESP8266_NONOS_SDK-2.2.1
CC user/acl.c
CC user/config_flash.c
CC user/rboot-api.c
CC user/rboot-ota.c
CC user/ringbuf.c
CC user/sys_time.c
CC user/user_main.c
user/user_main.c: In function 'gpio_change_handler':
user/user_main.c:1038:21: error: 'intptr_t' undeclared (first use in this function)
     uint16_t pin = (intptr_t)arg; // not used
```
added `#include "stdint.h"`

```
esp-open-sdk/xtensa-lx106-elf/lib/gcc/xtensa-lx106-elf/4.8.5/../../../../xtensa-lx106-elf/bin/ld: cannot open linker script file eagle.rom.addr.v6.ld: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [firmware/0x02000.bin] Error 1
```
added  `-L$(SDK_BASE)/ld`

```
make
/Users/hmueller/src/esp8266/esp_wifi_repeater.hmueller01/../esp-open-sdk/sdk/lib/libmain.a(app_main.o): In function `user_uart_wait_tx_fifo_empty':
(.irom0.text+0x7dc): undefined reference to `user_pre_init'
/Users/hmueller/src/esp8266/esp_wifi_repeater.hmueller01/../esp-open-sdk/sdk/lib/libmain.a(app_main.o): In function `flash_data_check':
(.irom0.text+0x848): undefined reference to `user_pre_init'
/Users/hmueller/src/esp8266/esp_wifi_repeater.hmueller01/../esp-open-sdk/sdk/lib/libwpa.a(wpa_auth.o):(.text.__wpa_send_eapol+0xc): undefined reference to `aes_wrap'
/Users/hmueller/src/esp8266/esp_wifi_repeater.hmueller01/../esp-open-sdk/sdk/lib/libwpa.a(wpa_auth.o): In function `__wpa_send_eapol':
(.text.__wpa_send_eapol+0x3e2): undefined reference to `aes_wrap'
```
added libs `crypto`