### PR TITLE
Fix user/user_main.c:1194:0: error: unterminated #ifndef

### DIFF
--- a/user/user_main.c
+++ b/user/user_main.c
@@ -1193,7 +1193,8 @@ void ICACHE_FLASH_ATTR console_handle_command(struct espconn *pespconn)
         to_console(response);
 #ifndef REPEATER_MODE
         os_sprintf_flash(response, "set [network|dns|ip|netmask|gw] <val>\r\n");
-        to_console(response);#endif
+        to_console(response);
+#endif
 #if HAVE_ENC28J60
 #if DCHPSERVER_ENC28J60
         os_sprintf_flash(response, "set [eth_dhcpd] <val>\r\n");


### PR DESCRIPTION
## Summary
- Fixes a syntax issue in `user/user_main.c` where `#endif` was accidentally appended to a C statement (`to_console(response);#endif`) inside `console_handle_command`.
- Places `#endif` on its own line so the `#ifndef REPEATER_MODE` block is properly terminated.
- Prevents cascading compile failures (stray `#`, undeclared `endif`, and unterminated conditional compilation block errors).





## Detailed error

```
root@7322774de2df:/home/esp/esp_wifi_repeater# make
CC driver/spi.c
CC driver/new_uart.c
CC user/config_flash.c
CC user/ringbuf.c
CC user/rboot-ota.c
CC user/acl.c
CC user/bridge.c
CC user/user_main.c
user/user_main.c: In function 'console_handle_command':
user/user_main.c:1196:30: error: stray '#' in program
         to_console(response);#endif
                              ^
user/user_main.c:1196:31: error: 'endif' undeclared (first use in this function)
         to_console(response);#endif
                               ^
user/user_main.c:1196:31: note: each undeclared identifier is reported only once for each function it appears in
user/user_main.c:63:5: error: expected ';' before 'do'
     do                                                                     \
     ^
user/user_main.c:1206:9: note: in expansion of macro 'os_sprintf_flash'
         os_sprintf_flash(response, "set [max_nat|max_portmap|tcp_timeout|udp_timeout] <val>\r\nroute clear|route add <network> <gw>|route delete <network>\r\ninterface <int> [up|down]\r\nportmap [add|remove] [TCP|UDP] <ext_port> <int_addr> <int_port>\r\n");
         ^
user/user_main.c: At top level:
user/user_main.c:1194:0: error: unterminated #ifndef
 #ifndef REPEATER_MODE
 ^
Makefile:184: recipe for target 'build/user/user_main.o' failed
make: *** [build/user/user_main.o] Error 1

````